### PR TITLE
Potential fix for code scanning alert no. 5: Insecure randomness

### DIFF
--- a/awstats/js/awstats_misc_tracker.js
+++ b/awstats/js/awstats_misc_tracker.js
@@ -87,7 +87,9 @@ if (window.location.search == "" || window.location.search == "?") {
 	TRKjava=navigator.javaEnabled();
 	TRKuserid=awstats_getCookie("AWSUSER_ID");
 	TRKsessionid=awstats_getCookie("AWSSESSION_ID");
-	var TRKrandomnumber=Math.floor(Math.random()*10000);
+	var array = new Uint32Array(1);
+	window.crypto.getRandomValues(array);
+	var TRKrandomnumber = array[0];
 	if (TRKuserid == null || (TRKuserid=="")) { TRKuserid = "awsuser_id" + TRKnow.getTime() +"r"+ TRKrandomnumber; }
 	if (TRKsessionid == null || (TRKsessionid=="")) { TRKsessionid = "awssession_id" + TRKnow.getTime() +"r"+ TRKrandomnumber; }
 	awstats_setCookie("AWSUSER_ID", TRKuserid, 10000);


### PR DESCRIPTION
Potential fix for [https://github.com/mgeli74/med/security/code-scanning/5](https://github.com/mgeli74/med/security/code-scanning/5)

To fix the problem, we need to replace the use of `Math.random()` with a cryptographically secure random number generator. For JavaScript in the browser, we can use `crypto.getRandomValues` to generate a secure random number. This ensures that the generated session ID is not easily predictable.

We will modify the code to use `crypto.getRandomValues` to generate a secure random number and then use this number to create the session ID. This change will be made in the `awstats/js/awstats_misc_tracker.js` file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
