### PR TITLE
Potential fix for code scanning alert no. 6: DOM text reinterpreted as HTML

### DIFF
--- a/static/bootstrap/js/bootstrap.bundle.js
+++ b/static/bootstrap/js/bootstrap.bundle.js
@@ -1102,7 +1102,7 @@
         return;
       }
 
-      var target = $__default['default'](selector)[0];
+      var target = document.querySelector(selector);
 
       if (!target || !$__default['default'](target).hasClass(CLASS_NAME_CAROUSEL)) {
         return;


### PR DESCRIPTION
Potential fix for [https://github.com/mgeli74/med/security/code-scanning/6](https://github.com/mgeli74/med/security/code-scanning/6)

To fix the problem, we need to ensure that the `selector` derived from the `data-target` attribute is properly sanitized before being used in a jQuery selector. One way to achieve this is by using the `$.find` method instead of `$`, which interprets the input as a CSS selector and not as HTML, thereby preventing XSS attacks.

- Replace the usage of `$__default['default'](selector)` with `document.querySelector(selector)` to ensure that the selector is valid and safe.
- If the selector is valid, use `$.find` to manipulate the DOM element safely.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
