### PR TITLE
Potential fix for code scanning alert no. 7: DOM text reinterpreted as HTML

### DIFF
--- a/static/bootstrap/js/bootstrap.js
+++ b/static/bootstrap/js/bootstrap.js
@@ -1103,7 +1103,7 @@
         return;
       }
 
-      var target = $__default['default'](selector)[0];
+      var target = $__default['default'](document).find(selector)[0];
 
       if (!target || !$__default['default'](target).hasClass(CLASS_NAME_CAROUSEL)) {
         return;


### PR DESCRIPTION
Potential fix for [https://github.com/mgeli74/med/security/code-scanning/7](https://github.com/mgeli74/med/security/code-scanning/7)

To fix the problem, we need to ensure that the `selector` variable is treated as a CSS selector and not as HTML. This can be achieved by using the `$.find` method instead of the `$` method, which will interpret the `selector` as a CSS selector and not as HTML. This change should be made in the `Carousel._dataApiClickHandler` function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
