### PR TITLE
Potential fix for code scanning alert no. 9: DOM text reinterpreted as HTML

### DIFF
--- a/store/templates/store/checkout.html
+++ b/store/templates/store/checkout.html
@@ -49,7 +49,8 @@
         row.addEventListener('click', function() {
             const productId = this.getAttribute('data-product-id');
             if (productId) {
-                window.location.href = `/store/product/${productId}/`; // Исправленный путь
+                const sanitizedProductId = encodeURIComponent(productId);
+                window.location.href = `/store/product/${sanitizedProductId}/`; // Исправленный путь
             }
         });
     });


### PR DESCRIPTION
Potential fix for [https://github.com/mgeli74/med/security/code-scanning/9](https://github.com/mgeli74/med/security/code-scanning/9)

To fix the problem, we need to ensure that the `productId` is properly sanitized before being used to construct the URL. One way to do this is to use a function that escapes any potentially dangerous characters in the `productId`. This will prevent any injected HTML or JavaScript from being executed.

The best way to fix this without changing existing functionality is to use a JavaScript function to encode the `productId` before using it in the URL. We can use the `encodeURIComponent` function, which is built into JavaScript and is designed to escape characters that have special meaning in URLs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
