### PR TITLE
Potential fix for code scanning alert no. 10: DOM text reinterpreted as HTML

### DIFF
--- a/store/templates/store/delivery.html
+++ b/store/templates/store/delivery.html
@@ -83,6 +83,19 @@
 {% endblock %}
 {% block scripts %}
 <script>
+    // Функция для экранирования HTML
+    function escapeHTML(str) {
+        return str.replace(/[&<>"']/g, function (match) {
+            const escapeMap = {
+                '&': '&amp;',
+                '<': '&lt;',
+                '>': '&gt;',
+                '"': '&quot;',
+                "'": '&#39;'
+            };
+            return escapeMap[match];
+        });
+    }
     // Получаем модальное окно
     const modal = document.getElementById("orderModal");
     // Получаем элемент для закрытия модального окна
@@ -93,8 +106,8 @@
     document.querySelectorAll(".order-row").forEach(row => {
         row.addEventListener("click", () => {
             // Получаем данные о заказе из атрибутов data
-            const orderId = row.getAttribute("data-order-id");
-            const orderDetails = row.getAttribute("data-order-details") || "Нет дополнительных деталей";
+            const orderId = escapeHTML(row.getAttribute("data-order-id"));
+            const orderDetails = escapeHTML(row.getAttribute("data-order-details") || "Нет дополнительных деталей");
             // Вставляем данные в модальное окно
             modalBody.innerHTML = `
                 <p><strong>Номер заказа:</strong> ${orderId}</p>


### PR DESCRIPTION
Potential fix for [https://github.com/mgeli74/med/security/code-scanning/10](https://github.com/mgeli74/med/security/code-scanning/10)

To fix the problem, we need to ensure that any data inserted into the HTML is properly escaped to prevent XSS attacks. This can be achieved by using a function to escape HTML special characters before inserting the data into the DOM.

- We will create a function `escapeHTML` that will replace special characters with their corresponding HTML entities.
- We will use this function to escape the `orderId` and `orderDetails` before inserting them into the HTML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
