### PR TITLE
Potential fix for code scanning alert no. 10: DOM text reinterpreted as HTML

### DIFF
--- a/store/templates/store/delivery.html
+++ b/store/templates/store/delivery.html
@@ -111,11 +111,11 @@
             // Вставляем данные в модальное окно
             modalBody.innerHTML = `
                 <p><strong>Номер заказа:</strong> ${orderId}</p>
-                <p><strong>Товар:</strong> ${row.cells[1].textContent}</p>
-                <p><strong>Количество:</strong> ${row.cells[2].textContent}</p>
-                <p><strong>Адрес доставки:</strong> ${row.cells[3].textContent}</p>
-                <p><strong>Дата заказа:</strong> ${row.cells[4].textContent}</p>
-                <p><strong>Статус:</strong> ${row.cells[5].textContent}</p>
+                <p><strong>Товар:</strong> ${escapeHTML(row.cells[1].textContent)}</p>
+                <p><strong>Кол��честв��:</strong> ${escapeHTML(row.cells[2].textContent)}</p>
+                <p><strong>Адрес доставки:</strong> ${escapeHTML(row.cells[3].textContent)}</p>
+                <p><strong>Дата заказа:</strong> ${escapeHTML(row.cells[4].textContent)}</p>
+                <p><strong>Статус:</strong> ${escapeHTML(row.cells[5].textContent)}</p>
                 <p><strong>Дополнительные детали:</strong> ${orderDetails}</p>
             `;
             // Отображаем модальное окно


### PR DESCRIPTION
Potential fix for [https://github.com/mgeli74/med/security/code-scanning/10](https://github.com/mgeli74/med/security/code-scanning/10)

To fix the problem, we need to ensure that all text content from the DOM is properly escaped before being inserted into the HTML of the modal body. We can achieve this by using the existing `escapeHTML` function to escape the text content of the table cells before inserting it into the modal body.

- Update the code to use the `escapeHTML` function for all text content from the table cells.
- Specifically, modify lines 114 to 118 to escape the text content of the table cells before inserting it into the modal body.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
